### PR TITLE
1) Fixed dot size setup. 2) Add IBInspectable. 2) Fixed Swift interop issue

### DIFF
--- a/TAPageControl/TAPageControl.h
+++ b/TAPageControl/TAPageControl.h
@@ -10,7 +10,6 @@
 
 @protocol TAPageControlDelegate;
 
-
 @interface TAPageControl : UIControl
 
 
@@ -39,13 +38,15 @@
 /**
  *  Dot size for dot views. Default is 8 by 8.
  */
-@property (nonatomic) CGSize dotSize;
+
+@property (nonatomic) IBInspectable CGSize dotSize;
 
 
 /**
  *  Spacing between two dot views. Default is 8.
  */
-@property (nonatomic) NSInteger spacingBetweenDots;
+
+@property (nonatomic) IBInspectable NSInteger spacingBetweenDots;
 
 
 /**
@@ -62,25 +63,25 @@
 /**
  *  Number of pages for control. Default is 0.
  */
-@property (nonatomic) NSInteger numberOfPages;
+@property (nonatomic) IBInspectable NSInteger numberOfPages;
 
 
 /**
  *  Current page on which control is active. Default is 0.
  */
-@property (nonatomic) NSInteger currentPage;
+@property (nonatomic) IBInspectable NSInteger currentPage;
 
 
 /**
  *  Hide the control if there is only one page. Default is NO.
  */
-@property (nonatomic) BOOL hidesForSinglePage;
+@property (nonatomic) IBInspectable BOOL hidesForSinglePage;
 
 
 /**
  *  Let the control know if should grow bigger by keeping center, or just get longer (right side expanding). By default YES.
  */
-@property (nonatomic) BOOL shouldResizeFromCenter;
+@property (nonatomic) IBInspectable BOOL shouldResizeFromCenter;
 
 
 /**

--- a/TAPageControl/TAPageControl.h
+++ b/TAPageControl/TAPageControl.h
@@ -100,6 +100,6 @@
 @protocol TAPageControlDelegate <NSObject>
 
 @optional
-- (void)TAPageControl:(TAPageControl *)pageControl didSelectPageAtIndex:(NSInteger)index;
+- (void)taPageControl:(TAPageControl *)pageControl didSelectPageAtIndex:(NSInteger)index;
 
 @end

--- a/TAPageControl/TAPageControl.m
+++ b/TAPageControl/TAPageControl.m
@@ -113,8 +113,8 @@ static CGSize const kDefaultDotSize = {8, 8};
     UITouch *touch = [touches anyObject];
     if (touch.view != self) {
         NSInteger index = [self.dots indexOfObject:touch.view];
-        if ([self.delegate respondsToSelector:@selector(TAPageControl:didSelectPageAtIndex:)]) {
-            [self.delegate TAPageControl:self didSelectPageAtIndex:index];
+        if ([self.delegate respondsToSelector:@selector(taPageControl:didSelectPageAtIndex:)]) {
+            [self.delegate taPageControl:self didSelectPageAtIndex:index];
         }
     }
 }

--- a/TAPageControl/TAPageControl.m
+++ b/TAPageControl/TAPageControl.m
@@ -102,6 +102,7 @@ static CGSize const kDefaultDotSize = {8, 8};
     self.currentPage            = kDefaultCurrentPage;
     self.hidesForSinglePage     = kDefaultHideForSinglePage;
     self.shouldResizeFromCenter = kDefaultShouldResizeFromCenter;
+    _dotSize = kDefaultDotSize;
 }
 
 
@@ -311,27 +312,44 @@ static CGSize const kDefaultDotSize = {8, 8};
 
 - (void)setDotImage:(UIImage *)dotImage
 {
-    _dotImage = dotImage;
-    [self resetDotViews];
-    self.dotViewClass = nil;
+    if (_dotImage != dotImage)
+    {
+        _dotImage = dotImage;
+        self.dotSize = _dotImage.size;
+        [self resetDotViews];
+        self.dotViewClass = nil;
+    }
 }
 
 
 - (void)setCurrentDotImage:(UIImage *)currentDotimage
 {
-    _currentDotImage = currentDotimage;
-    [self resetDotViews];
-    self.dotViewClass = nil;
+    if (_currentDotImage != currentDotimage)
+    {
+        _currentDotImage = currentDotimage;
+        [self resetDotViews];
+        self.dotViewClass = nil;
+    }
 }
 
 
 - (void)setDotViewClass:(Class)dotViewClass
 {
-    _dotViewClass = dotViewClass;
-    self.dotSize = CGSizeZero;
-    [self resetDotViews];
+    if (_dotViewClass != dotViewClass)
+    {
+        _dotViewClass = dotViewClass;
+        [self resetDotViews];
+    }
 }
 
+- (void)setDotSize:(CGSize)dotSize
+{
+    if (_dotSize.height != dotSize.height || _dotSize.width != dotSize.width)
+    {
+        _dotSize = dotSize;
+        [self resetDotViews];
+    }
+}
 
 #pragma mark - Getters
 
@@ -343,20 +361,6 @@ static CGSize const kDefaultDotSize = {8, 8};
     }
     
     return _dots;
-}
-
-
-- (CGSize)dotSize
-{
-    // Dot size logic depending on the source of the dot view
-    if (self.dotImage && CGSizeEqualToSize(_dotSize, CGSizeZero)) {
-        _dotSize = self.dotImage.size;
-    } else if (self.dotViewClass && CGSizeEqualToSize(_dotSize, CGSizeZero)) {
-        _dotSize = kDefaultDotSize;
-        return _dotSize;
-    }
-    
-    return _dotSize;
 }
 
 @end


### PR DESCRIPTION
Hi, I've fixed dot size setup, because it was always 8pt in size. I also added IBInspectable attribute to the properties of the supported types.
